### PR TITLE
remove width restriction on content container

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,6 +1,4 @@
 <script src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
-<script src="js/plugins.js"></script>
-<script src="js/main.js"></script>
 
 <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
 <script>

--- a/_sass/_scaffolding.scss
+++ b/_sass/_scaffolding.scss
@@ -18,8 +18,7 @@ a {
 }
 
 .container {
-  width: 60em;
-  margin: 0 auto;
+  margin: 0 2em;
 }
 
 %heading {

--- a/_site/about.html
+++ b/_site/about.html
@@ -36,7 +36,7 @@
     </a>
   </li>
   <li>
-    <a href="https://www.instagram.com/">
+    <a href="https://www.instagram.com/indivisiblebrooklyn">
       <i class="fa fa-instagram"></i>
     </a>
   </li>
@@ -85,7 +85,7 @@
     </a>
   </li>
   <li>
-    <a href="https://www.instagram.com/">
+    <a href="https://www.instagram.com/indivisiblebrooklyn">
       <i class="fa fa-instagram"></i>
     </a>
   </li>
@@ -96,8 +96,6 @@
 
 
         <script src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
-<script src="js/plugins.js"></script>
-<script src="js/main.js"></script>
 
 <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
 <script>

--- a/_site/css/main.css
+++ b/_site/css/main.css
@@ -144,7 +144,7 @@ a { color: #318493; }
 
 .wrapper { background-color: #fafafa; overflow: hidden; padding: 4em 0; }
 
-.container { width: 60em; margin: 0 auto; }
+.container { margin: 0 2em; }
 
 h1, h2, h3, h4, h5, h6 { text-transform: uppercase; color: rgba(153, 11, 11, 0.73); font-weight: 400; margin: 0 0 calc(0.5rem + 0.25em); }
 

--- a/_site/index.html
+++ b/_site/index.html
@@ -36,7 +36,7 @@
     </a>
   </li>
   <li>
-    <a href="https://www.instagram.com/">
+    <a href="https://www.instagram.com/indivisiblebrooklyn">
       <i class="fa fa-instagram"></i>
     </a>
   </li>
@@ -145,7 +145,7 @@
     </a>
   </li>
   <li>
-    <a href="https://www.instagram.com/">
+    <a href="https://www.instagram.com/indivisiblebrooklyn">
       <i class="fa fa-instagram"></i>
     </a>
   </li>
@@ -156,8 +156,6 @@
 
 
         <script src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
-<script src="js/plugins.js"></script>
-<script src="js/main.js"></script>
 
 <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
 <script>


### PR DESCRIPTION
For issue https://github.com/josephspens/indivisible-brooklyn/issues/3

Removing the width restriction on the content container allows it to be fully responsive and looks fine on a large screen. Also removes a reference to some javascript that doesn't exist. 

<img width="400" alt="screenshot 2017-03-05 18 39 30" src="https://cloud.githubusercontent.com/assets/2053928/23592717/3b5c48a8-01d3-11e7-9ec1-d0f9c270c2c3.png">
<img width="1025" alt="screenshot 2017-03-05 18 41 23" src="https://cloud.githubusercontent.com/assets/2053928/23592729/5ccc8304-01d3-11e7-8e20-af560b44c9f7.png">
