### PR TITLE
add pitch

### DIFF
--- a/_sass/_scaffolding.scss
+++ b/_sass/_scaffolding.scss
@@ -21,6 +21,11 @@ a {
   margin: 0 2em;
 }
 
+.text-block {
+  margin: 2em auto 0 auto;
+  width: 75%;
+}
+
 %heading {
   text-transform: uppercase;
   color: $secondary-color;
@@ -61,3 +66,4 @@ h5 {
 h6 {
   @extend %heading;
 }
+

--- a/_site/css/main.css
+++ b/_site/css/main.css
@@ -146,6 +146,8 @@ a { color: #318493; }
 
 .container { margin: 0 2em; }
 
+.text-block { margin: 2em auto 0 auto; width: 75%; }
+
 h1, h2, h3, h4, h5, h6 { text-transform: uppercase; color: rgba(153, 11, 11, 0.73); font-weight: 400; margin: 0 0 calc(0.5rem + 0.25em); }
 
 h1 { color: #001d59; font-size: 93px; letter-spacing: .09em; line-height: .86em; }

--- a/_site/index.html
+++ b/_site/index.html
@@ -48,6 +48,10 @@
         <div class="wrapper">
   <div class="hero-image"></div>
 
+  <div class="text-block">
+    Indivisible Brooklyn is part of the nationwide Indivisible grassroots movement and is open to all people dedicated to inclusion, tolerance and fairness. We are organizing to take political action in three areas: federal, state, and city governments. Our aim is to promote progressive policy through civic engagement, build strength in our community, and block the the regressive policies of the Trump administration.
+  </div>
+
   <div class="signup-form">
     <h2>Sign up to get updates from Indivisible Brooklyn and get involved in local activism.</h2>
     <!-- Begin MailChimp Signup Form -->

--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@ title: Indivisible Brooklyn
 <div class="wrapper">
   <div class="hero-image"></div>
 
+  <div class="text-block">
+    Indivisible Brooklyn is part of the nationwide Indivisible grassroots movement and is open to all people dedicated to inclusion, tolerance and fairness. We are organizing to take political action in three areas: federal, state, and city governments. Our aim is to promote progressive policy through civic engagement, build strength in our community, and block the the regressive policies of the Trump administration.
+  </div>
+
   <div class="signup-form">
     <h2>Sign up to get updates from Indivisible Brooklyn and get involved in local activism.</h2>
     {% include mailchimp.html %}


### PR DESCRIPTION
Add the elevator pitch:

could one of you add our Elevator Pitch below our banner and above the sign-up form? Ideally the sign-up form would still be visible above the fold if possible! "Indivisible Brooklyn is part of the nationwide Indivisible grassroots movement and is open to all people dedicated to inclusion, tolerance and fairness. We are organizing to take political action in three areas: federal, state, and city governments. Our aim is to promote progressive policy through civic engagement, build strength in our community, and block the the regressive policies of the Trump administration."
